### PR TITLE
Fix a typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ myCrystal.add_atom(atom=myAtom)
 
 # Create parabolic bands in reciprocal space
 from pyeels import ParabolicBand
-reci = ParabolicBand(mySystem)
+reci = ParabolicBand(myCrystal)
 
 reci.set_grid(mesh=31) # Number of k-points in each dimension
 


### PR DESCRIPTION
mySystem has not been declared at this point, implying that this is a typo. You messaged me saying that it should probably be myCrystal, so here is that change.